### PR TITLE
Fix submission validation

### DIFF
--- a/operatorcert/__init__.py
+++ b/operatorcert/__init__.py
@@ -82,7 +82,7 @@ def get_supported_indices(
     """
     url = urljoin(pyxis_url, "v1/operators/indices")
 
-    filter_ = f"organization==certified-operators"
+    filter_ = "organization==certified-operators"
     if max_ocp_version:
         filter_ += f";ocp_version=le={max_ocp_version}"
 
@@ -277,11 +277,11 @@ def verify_pr_uniqueness(
     Find Pull Requests for the same Operator Bundle, and error if they exists.
     """
 
-    base_url = f"https://api.github.com/repos/"
+    base_url = "https://api.github.com/repos/"
 
     # complex regex of semver is replaced with regex valid for any string without whistespaces
     # - no need to validate semver anymore
-    regex = f"^operator ([a-zA-Z0-9-]+) [^\s]+$"
+    regex = r"^operator ([a-zA-Z0-9-]+) [^\s]+$"
     regex_pattern = re.compile(regex)
 
     for repo in available_repositories:
@@ -299,6 +299,9 @@ def verify_pr_uniqueness(
                 # We found the base PR
                 continue
             matching = regex_pattern.search(pr_title)
+            # there is a PR with name that doesn't conform to regex
+            if matching is None:
+                continue
             bundle_name = matching.group(1)
             if bundle_name == base_pr_bundle_name:
                 duplicate_prs.append(f"{pr_title}: {pr_url}")

--- a/operatorcert/__init__.py
+++ b/operatorcert/__init__.py
@@ -303,6 +303,9 @@ def verify_pr_uniqueness(
             if matching is None:
                 continue
             bundle_name = matching.group(1)
+            # there is a PR with name that doesn't conform to regex
+            if matching is None:
+                continue
             if bundle_name == base_pr_bundle_name:
                 duplicate_prs.append(f"{pr_title}: {pr_url}")
 

--- a/operatorcert/__init__.py
+++ b/operatorcert/__init__.py
@@ -303,9 +303,6 @@ def verify_pr_uniqueness(
             if matching is None:
                 continue
             bundle_name = matching.group(1)
-            # there is a PR with name that doesn't conform to regex
-            if matching is None:
-                continue
             if bundle_name == base_pr_bundle_name:
                 duplicate_prs.append(f"{pr_title}: {pr_url}")
 

--- a/tests/test_operatorcert.py
+++ b/tests/test_operatorcert.py
@@ -250,7 +250,7 @@ def test_verify_pr_uniqueness(mock_get: MagicMock):
             {
                 "title": "title not conforming regex- should not throw error",
                 "html_url": base_pr_url.replace("1", "4"),
-            }
+            },
         ],
         # At second call return:
         [

--- a/tests/test_operatorcert.py
+++ b/tests/test_operatorcert.py
@@ -247,12 +247,16 @@ def test_verify_pr_uniqueness(mock_get: MagicMock):
                 "title": "operator third (1.2.3)",
                 "html_url": base_pr_url.replace("1", "3"),
             },
+            {
+                "title": "title not conforming regex- should not throw error",
+                "html_url": base_pr_url.replace("1", "4"),
+            }
         ],
         # At second call return:
         [
             {
                 "title": "operator fourth (1.2.3)",
-                "html_url": base_pr_url.replace("1", "4"),
+                "html_url": base_pr_url.replace("1", "5"),
             }
         ],
     ]


### PR DESCRIPTION
Submission validation script parses the existing PRs titles, to see to which operator bundle they belong. 
In case PR title doesn't conform to a regex, the script should not fail.