### PR TITLE
Log association name when operator name is taken by another association

### DIFF
--- a/operatorcert/entrypoints/reserve_operator_name.py
+++ b/operatorcert/entrypoints/reserve_operator_name.py
@@ -49,7 +49,7 @@ def check_operator_name(args) -> None:
         if package["association"] != args.association:
             LOGGER.error(
                 f"Operator name {args.operator_name} is already taken by another "
-                f"association."
+                f"association ({package['association']})."
             )
             sys.exit(1)
         else:


### PR DESCRIPTION
This was suggested during the community meeting to help with debugging.
Privacy was not a concern since there's not much one can do with
just the assocation name without the right API key.