### PR TITLE
Accepting https and ssh schema in verify_changed_dirs step

### DIFF
--- a/operatorcert/__init__.py
+++ b/operatorcert/__init__.py
@@ -2,7 +2,7 @@ import json
 import logging
 import pathlib
 import re
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin
 from typing import Dict, List, Optional
 
 import requests
@@ -158,15 +158,20 @@ def get_repo_and_org_from_github_url(git_repo_url: str) -> (str, str):
 
     wrong_path_err = (
         f"{git_repo_url} is not a valid repository link. "
-        f"Valid link should look like "
-        f"'git@github.com:redhat-openshift-ecosystem/operator-pipelines.git'"
+        f"Valid link should either look like "
+        f"'git@github.com:redhat-openshift-ecosystem/operator-pipelines.git' or "
+        f"'https://github.com/redhat-openshift-ecosystem/operator-pipelines.git'"
     )
 
-    parsed = urlparse(git_repo_url)
-    path = parsed.path
-    if not path.startswith("git@github.com:") or not path.endswith(".git"):
+    # ssh path
+    if git_repo_url.startswith("git@github.com:") and git_repo_url.endswith(".git"):
+        path = git_repo_url.removeprefix("git@github.com:").removesuffix(".git")
+    # https path
+    elif git_repo_url.startswith("https://github.com/") and git_repo_url.endswith(".git"):
+        path = git_repo_url.removeprefix("https://github.com/").removesuffix(".git")
+    else:
         raise ValueError(wrong_path_err)
-    path = parsed.path.removeprefix("git@github.com:").removesuffix(".git")
+
     path_components = path.split("/")
     if len(path_components) != 2:
         raise ValueError(wrong_path_err)

--- a/operatorcert/__init__.py
+++ b/operatorcert/__init__.py
@@ -167,7 +167,9 @@ def get_repo_and_org_from_github_url(git_repo_url: str) -> (str, str):
     if git_repo_url.startswith("git@github.com:") and git_repo_url.endswith(".git"):
         path = git_repo_url.removeprefix("git@github.com:").removesuffix(".git")
     # https path
-    elif git_repo_url.startswith("https://github.com/") and git_repo_url.endswith(".git"):
+    elif git_repo_url.startswith("https://github.com/") and git_repo_url.endswith(
+        ".git"
+    ):
         path = git_repo_url.removeprefix("https://github.com/").removesuffix(".git")
     else:
         raise ValueError(wrong_path_err)

--- a/operatorcert/entrypoints/verify_changed_dirs.py
+++ b/operatorcert/entrypoints/verify_changed_dirs.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-import sys
 
 from operatorcert import (
     get_files_added_in_pr,

--- a/tests/test_operatorcert.py
+++ b/tests/test_operatorcert.py
@@ -113,22 +113,23 @@ def test_ocp_version_info(mock_indices: MagicMock, bundle: Bundle) -> None:
 
 
 def test_get_repo_and_org_from_github_url():
-    org, repo = operatorcert.get_repo_and_org_from_github_url(
-        "git@github.com:redhat-openshift-ecosystem/operator-pipelines.git"
-    )
-    assert org == "redhat-openshift-ecosystem"
-    assert repo == "operator-pipelines"
+    # test http and ssh
+    for url in ["git@github.com:redhat-openshift-ecosystem/operator-pipelines.git",
+                "https://github.com/redhat-openshift-ecosystem/operator-pipelines.git"]:
+        org, repo = operatorcert.get_repo_and_org_from_github_url(url)
+        assert org == "redhat-openshift-ecosystem"
+        assert repo == "operator-pipelines"
+
+    # wrong schema
+    with pytest.raises(ValueError):
+        operatorcert.get_repo_and_org_from_github_url(
+            "github.com/redhat-openshift-ecosystem/operator-pipelines/something"
+        )
 
     # wrong amount of url segments
     with pytest.raises(ValueError):
         operatorcert.get_repo_and_org_from_github_url(
             "git@github.com:redhat-openshift-ecosystem/operator-pipelines/something.git"
-        )
-
-    # https instead of ssh
-    with pytest.raises(ValueError):
-        operatorcert.get_repo_and_org_from_github_url(
-            "https://github.com/redhat-openshift-ecosystem/operator-pipelines/something.git"
         )
 
 

--- a/tests/test_operatorcert.py
+++ b/tests/test_operatorcert.py
@@ -114,8 +114,10 @@ def test_ocp_version_info(mock_indices: MagicMock, bundle: Bundle) -> None:
 
 def test_get_repo_and_org_from_github_url():
     # test http and ssh
-    for url in ["git@github.com:redhat-openshift-ecosystem/operator-pipelines.git",
-                "https://github.com/redhat-openshift-ecosystem/operator-pipelines.git"]:
+    for url in [
+        "git@github.com:redhat-openshift-ecosystem/operator-pipelines.git",
+        "https://github.com/redhat-openshift-ecosystem/operator-pipelines.git",
+    ]:
         org, repo = operatorcert.get_repo_and_org_from_github_url(url)
         assert org == "redhat-openshift-ecosystem"
         assert repo == "operator-pipelines"


### PR DESCRIPTION
The hosted pipeline should be able to run with the https schemas.
Related PR: https://github.com/redhat-openshift-ecosystem/operator-pipelines/pull/46