### PR TITLE
Rename 'production' to 'prod'

### DIFF
--- a/operatorcert/entrypoints/publish.py
+++ b/operatorcert/entrypoints/publish.py
@@ -31,7 +31,7 @@ def setup_argparser() -> Any:
     parser.add_argument(
         "--environment",
         help="Environment where a tool runs",
-        choices=["production", "stage", "dev", "qa"],
+        choices=["prod", "stage", "dev", "qa"],
         default="dev",
     )
 

--- a/operatorcert/utils.py
+++ b/operatorcert/utils.py
@@ -59,7 +59,7 @@ def get_registry_for_env(environment: str) -> str:
         str: Connect registry for current
     """
     env_to_registry = {
-        "production": "registry.connect.redhat.com",
+        "prod": "registry.connect.redhat.com",
         "stage": "registry.connect.stage.redhat.com",
         "qa": "registry.connect.qa.redhat.com",
         "dev": "registry.connect.dev.redhat.com",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,7 +53,7 @@ def test_store_results() -> None:
 
 
 def test_get_registry_for_env() -> None:
-    assert utils.get_registry_for_env("production") == "registry.connect.redhat.com"
+    assert utils.get_registry_for_env("prod") == "registry.connect.redhat.com"
     assert utils.get_registry_for_env("stage") == "registry.connect.stage.redhat.com"
     assert utils.get_registry_for_env("qa") == "registry.connect.qa.redhat.com"
     assert utils.get_registry_for_env("dev") == "registry.connect.dev.redhat.com"


### PR DESCRIPTION
To align recent changes in pipeline repo we have to rename prod
environment naming.